### PR TITLE
Added Nested AG-Grid table(s) to search page to display search info

### DIFF
--- a/frontend/HelperFuncs/utils.js
+++ b/frontend/HelperFuncs/utils.js
@@ -249,3 +249,48 @@ export const getMatchingUsers = async(searchTerm) => {
     console.log(data)
     return data;
 }
+
+
+/*
+helper function to format the rows of the AG-Grid component on search pages
+*/
+export function getSearchRows(userData) {
+    console.log('userData', userData)
+    let rows = [];
+    for (let i =0 ; i < userData.length ; i++){
+        const user = userData[i]
+        let transactionRows = [];
+        const transactions = user.transaction
+        for(const category in transactions){
+            // this loop content is copied over from [getRows] except for average and difference columns which are profile-table exclusives
+            if (transactions[category]) {
+                const { total_percent, details } = transactions[category];
+                const roundedTotalPercent = parseFloat(total_percent.toFixed(2));
+                transactionRows.push({
+                    category: [category],
+                    your_percent: `${roundedTotalPercent}%`,
+                    your_percent_value: roundedTotalPercent,
+                });
+                for(let i=0; i < details.length; i++){
+                    if(details[i].name != category) {
+                        transactionRows.push({
+                            category: [category, details[i].name],
+                            your_percent: `${parseFloat(details[i].percent.toFixed(2))}%`,
+                            your_percent_value: parseFloat(details[i].percent.toFixed(2)),
+                        })
+                    }   
+                }
+            } 
+        }
+        rows.push({
+            city: `${user.city}, ${user.state} `,
+            job: user.job,
+            salary: user.salary,
+            dependents: user.children,
+            roommates: user.roommates,
+            children: transactionRows
+
+        })
+    }
+    return rows
+}

--- a/frontend/HelperFuncs/utils.js
+++ b/frontend/HelperFuncs/utils.js
@@ -246,7 +246,6 @@ export const getMatchingUsers = async(searchTerm) => {
         throw new Error('Network response was not ok at fetchProfile', Error);
     }
     const data = await response.json();
-    console.log(data)
     return data;
 }
 
@@ -255,7 +254,6 @@ export const getMatchingUsers = async(searchTerm) => {
 helper function to format the rows of the AG-Grid component on search pages
 */
 export function getSearchRows(userData) {
-    console.log('userData', userData)
     let rows = [];
     for (let i =0 ; i < userData.length ; i++){
         const user = userData[i]

--- a/frontend/src/HomePage/Top/Search.jsx
+++ b/frontend/src/HomePage/Top/Search.jsx
@@ -11,7 +11,7 @@ function Search() {
 
     // when a user first focuses on the search bar, they should see some default queries
     const defaultSearch =  [{label: 'Menlo Park, CA', category: 'city' },
-                           {label: '$87,076 - $170,050', category: 'salary'},
+                           {label: '$89,076 - $170,050', category: 'salary'},
                            {label: 'Software Engineer', category: 'job'}]
 
     /* search results are stored in terms of the label the user sees as well as the category of search term to allow 

--- a/frontend/src/SearchPage/SearchResults.css
+++ b/frontend/src/SearchPage/SearchResults.css
@@ -1,7 +1,13 @@
 .mainContent {
-    margin-top: 85%;
+    margin-top: 25vh;
     display: flex;
     white-space: nowrap;
     font-family: "Inter Tight", sans-serif;
-    margin-left: 120%;
+    margin-left: 20vw;
+    display: block;
+}
+
+.userList {
+    margin-top: 10vh;
+    margin-left: 20vw;
 }

--- a/frontend/src/SearchPage/SearchResults.css
+++ b/frontend/src/SearchPage/SearchResults.css
@@ -10,4 +10,10 @@
 .userList {
     margin-top: 10vh;
     margin-left: 20vw;
+    height: 100%;
 }
+
+.ag-row {
+    padding-right: 70px;
+  }
+

--- a/frontend/src/SearchPage/SearchResults.jsx
+++ b/frontend/src/SearchPage/SearchResults.jsx
@@ -51,7 +51,7 @@ function SearchResults() {
         detailGridOptions: {
             columnDefs: detailsColumnDefs,
             defaultColDef: {
-                width: 450
+                flex: 1
             },
             autoGroupColumnDef: {
                 headerName: "Category",
@@ -70,6 +70,10 @@ function SearchResults() {
         }
     };
 
+    const defaultColDef = useMemo(() => ({
+        flex: 1,
+    }), []);
+
     // the topbar users see depends on if they're logged in our not, as tracked by whether or not userId is in url
     const TopBarComponent = userId ? ProfileTopBar : Topbar;
     const search = decodeURIComponent(searchTerm)
@@ -81,12 +85,13 @@ function SearchResults() {
                 <h2>{search}</h2>
             </div>
             <div className='userList'>
-                <div className='ag-theme-alpine' style={{ height: 600, width: 1000 }}>
+                <div className='ag-theme-alpine' style={{ height: '100%', width: 1000 }}>
                     <AgGridReact 
                         rowData={rows}
                         columnDefs={userColumnDefs}
                         masterDetail={true}
                         detailCellRendererParams={detailCellRendererParams}
+                        defaultColDef={defaultColDef}
                     />
                 </div>
             </div>

--- a/frontend/src/SearchPage/SearchResults.jsx
+++ b/frontend/src/SearchPage/SearchResults.jsx
@@ -51,9 +51,7 @@ function SearchResults() {
         detailGridOptions: {
             columnDefs: detailsColumnDefs,
             defaultColDef: {
-                flex: 1,
-                resizable: true,
-                sortable: true
+                width: 450
             },
             autoGroupColumnDef: {
                 headerName: "Category",
@@ -89,12 +87,6 @@ function SearchResults() {
                         columnDefs={userColumnDefs}
                         masterDetail={true}
                         detailCellRendererParams={detailCellRendererParams}
-                        defaultColDef={{
-                            flex: 1,
-                            minWidth: 100,
-                            resizable: true,
-                            sortable: true
-                        }}
                     />
                 </div>
             </div>

--- a/frontend/src/SearchPage/SearchResults.jsx
+++ b/frontend/src/SearchPage/SearchResults.jsx
@@ -2,12 +2,12 @@ import './SearchResults.css'
 import { useParams } from 'react-router-dom';
 import Topbar from '../HomePage/Top/Topbar';
 import ProfileTopBar from '../ProfilePage/ProfileTopBar';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { AgGridReact } from "ag-grid-react";
 import "ag-grid-charts-enterprise";
 import "ag-grid-community/styles/ag-grid.css";
 import "ag-grid-community/styles/ag-theme-alpine.css";
-import { fetchTransaction, getMatchingUsers } from '../../HelperFuncs/utils';
+import { getMatchingUsers, getSearchRows } from '../../HelperFuncs/utils';
 
 function SearchResults() {
 
@@ -15,25 +15,22 @@ function SearchResults() {
     const [users, setUsers] = useState([]);
 
     const [userColumnDefs, setUserColumnDefs] = useState([
-        { field: "city", headerName: "City"},
+        { field: "city", headerName: "City", cellRenderer: 'agGroupCellRenderer'},
         { field: "salary", headerName: "Salary" },
         { field: "job", headerName: "Job" },
-        { fields: "children", headerName: "Children/Dependents"},
-        { fields: "roommates", headerName: "Roommates"}
+        { field: "dependents", headerName: "Children/Dependents"},
+        { field: "roommates", headerName: "Roommates"}
     ]);
-
     const [detailsColumnDefs, setDetailsColumnDefs] = useState([
         { field: "your_percent_value", headerName: "Percent"},
     ]);
 
-
-    const [userRows, setUserRows] = useState([]);
-    const [detailRows, setDetailRows] = useState([]);
+    const [rows, setRows] = useState([]);
 
     const getUsers = async () => {
         try {
-            const users = await getMatchingUsers(searchTerm)
-            setUsers(users)
+            const matchingUsers = await getMatchingUsers(searchTerm)
+            setUsers(matchingUsers)
         } catch (error) {
             console.error('Error fetching users:', error)
         }
@@ -42,6 +39,38 @@ function SearchResults() {
     useEffect( () => {
         getUsers(); 
     }, [searchTerm]);
+
+    useEffect( () => {
+        if(users) {
+            setRows(getSearchRows(users))
+        }
+    }, [users]);
+
+    // this object describes the inner transaction table for each user
+    const detailCellRendererParams = {
+        detailGridOptions: {
+            columnDefs: detailsColumnDefs,
+            defaultColDef: {
+                flex: 1,
+                resizable: true,
+                sortable: true
+            },
+            autoGroupColumnDef: {
+                headerName: "Category",
+                cellRendererParams: {
+                    suppressCount: false,
+                },
+            },
+            treeData: true,
+            getDataPath: function(data) {
+                return data.category; 
+            },
+            groupDefaultExpanded: 0,
+        },
+        getDetailRowData: function(params) {
+            params.successCallback(params.data.children);
+        }
+    };
 
     // the topbar users see depends on if they're logged in our not, as tracked by whether or not userId is in url
     const TopBarComponent = userId ? ProfileTopBar : Topbar;
@@ -54,7 +83,20 @@ function SearchResults() {
                 <h2>{search}</h2>
             </div>
             <div className='userList'>
-
+                <div className='ag-theme-alpine' style={{ height: 600, width: 1000 }}>
+                    <AgGridReact 
+                        rowData={rows}
+                        columnDefs={userColumnDefs}
+                        masterDetail={true}
+                        detailCellRendererParams={detailCellRendererParams}
+                        defaultColDef={{
+                            flex: 1,
+                            minWidth: 100,
+                            resizable: true,
+                            sortable: true
+                        }}
+                    />
+                </div>
             </div>
         </>
     )


### PR DESCRIPTION
## Description

<what this pull request is doing>

-  this PR adds the AG-Grid code to display the results of a search, completing the MVP version of the search feature

<what will be done in later PRs and not included here>

- next PR will be the last for MVP, completing the 'average' and 'difference' columns on the profile page


## Milestones

- Users can view a list of other users matching their search and see a  breakdown of their profile and transaction stats



## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>

I relied on [this](https://www.ag-grid.com/react-data-grid/master-detail-nesting/) doc to get the nested-table feature down 


## Test Plan
<insert images or gifs of feature>
<otherwise, say how code was tested if not UI facing>
<any edge cases you might have specifically tested>


https://github.com/user-attachments/assets/dafb9555-3d67-4340-b93c-6ab3532728c2

