### PR TITLE
filled similar users average and your difference columns on your profile page

### DIFF
--- a/frontend/HelperFuncs/utils.js
+++ b/frontend/HelperFuncs/utils.js
@@ -147,27 +147,53 @@ export const getRows = (transactions, similarUsers) => {
         if (transactions[category]) {
             const { total_percent, details } = transactions[category];
             const roundedTotalPercent = parseFloat(total_percent.toFixed(2));
+            // by default, average and difference are N/A to cover case of no simlar users
+            let average = 'N/A'
+            let difference = 'N/A'
+            // filter to ensure that similarUsers has at least one field for the category
+            const similarUsersForCategory = similarUsers.filter((user) => user[category]);
+            if (similarUsersForCategory.length > 0) {
+                const medianValues = similarUsersForCategory.map((user) => user[category].total_percent);
+                const medianValue = median(medianValues);
+                average = parseFloat(medianValue.toFixed(2));
+                difference = parseFloat((roundedTotalPercent - average).toFixed(2));
+            }
             rows.push({
                 category: [category],
                 your_percent: `${roundedTotalPercent}%`,
                 your_percent_value: roundedTotalPercent,
-                average: 'N/A',
-                difference: 'N/A' 
-            });
+                average: `${average}`,
+                difference: `${difference}` 
+            })
             for(let i=0; i < details.length; i++){
-                // this guard catches the catch-all categories travel and medical from appearing twice
-                if(details[i].name != category) {
-                    rows.push({
-                        category: [category, details[i].name],
-                        your_percent: `${parseFloat(details[i].percent.toFixed(2))}%`,
-                        your_percent_value: parseFloat(details[i].percent.toFixed(2)),
-                        average: 'N/A',
-                        difference: 'N/A'
-                    })
+                const detail = details[i];
+                let detailAverage = 'N/A';
+                let detailDifference = 'N/A';
+                /* extract each similar users detailed percent value if the relevant detailed field exists,
+                this is checked by mapping each element of the [similarUsers] list onto a check looking for the
+                relevant field name. If found, extract percent, otherwise null
+                */
+                const detailPercentages = similarUsersForCategory.map((user) => {
+                    const userDetail = user[category].details.find(detailItem => detailItem.name === detail.name);
+                    return userDetail ? userDetail.percent : null;
+                });
+                  // check to make sure we actually have data to take the median of, if not we have the default 'N/A'
+                  if (detailPercentages.length > 0) {
+                    const detailMedian = median(detailPercentages);
+                    detailAverage = parseFloat(detailMedian.toFixed(2));
+                    detailDifference = parseFloat((detail.percent - detailAverage).toFixed(2));
+                  }
+
+                  rows.push({
+                    category: [category, detail.name],
+                    your_percent: `${parseFloat(detail.percent.toFixed(2))}%`,
+                    your_percent_value: parseFloat(detail.percent.toFixed(2)),
+                    average: `${detailAverage}`,
+                    difference: `${detailDifference}`
+                  })
                 }
             }
         }
-    }
     return rows;
 };
 
@@ -260,6 +286,18 @@ export const fetchSimilarUsers = async(profileData) => {
       throw new Error('Network response was not ok at fetchSimilarUsers', Error);
     }
     const data = await response.json();
-    console.log(data)
     return data;
   }
+
+
+// helper function to return the median of an array [arr]
+function median(arr) {
+    const sorted = Array.from(arr).sort((a, b) => a - b);
+    const middle = Math.floor(sorted.length / 2);
+
+    if (sorted.length % 2 === 0) {
+        return (sorted[middle - 1] + sorted[middle]) / 2;
+    }
+
+    return sorted[middle];
+}

--- a/frontend/src/ProfilePage/Profile.css
+++ b/frontend/src/ProfilePage/Profile.css
@@ -63,9 +63,9 @@ h3 {
 .TransactionContent {
     margin-left: 30vw;
     margin-top: 10%;
-    width: 50vw;
+    width: 55vw;
     background-color: #F3F5F7;
-    height: 60vh;
+    height: 70vh;
 }
 
 .ag-theme-alpine {


### PR DESCRIPTION
## Description

<what this pull request is doing>

- this pull request finds the median expenditure percentage level for each category across similar users. Median was used instead of mean to normalize for outliers. 
- The difference (your percent - average) is found as well
- both of these values are put in your profile table for each row

<what will be done in later PRs and not included here>

## Milestones
<the milestones or stories/features that this works towards>
This request finishes the story:

- Users can receive analytics on how their category breakdown compares to other users with similar profiles (e.g. relative to other profiles you spend 17% more on rideshare, etc.)
- This also finishes my project MVP!

## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>
I used [this](https://stackoverflow.com/questions/45309447/calculating-median-javascript) Stack Overflow thread to help write the `median` helper to save time. 

## Test Plan
<img width="1070" alt="Screenshot 2024-07-15 at 12 34 44 AM" src="https://github.com/user-attachments/assets/abb4c9d6-74d3-4b9d-bec9-e97b0608fb98">

