### PR TITLE
added local storage caching for select and graph

### DIFF
--- a/frontend/src/ProfilePage/Chart.jsx
+++ b/frontend/src/ProfilePage/Chart.jsx
@@ -151,7 +151,8 @@ const Chart = ({ data, onSaveSvg }) => {
                 movedPointer(event);
             })
             .on("touchstart", event => event.preventDefault());
-
+        
+        // once the svg is rendered, cache it in localStorage
         if (onSaveSvg && svgRef.current) {
             onSaveSvg(svgRef.current);
         }   

--- a/frontend/src/ProfilePage/Chart.jsx
+++ b/frontend/src/ProfilePage/Chart.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
-const Chart = ({ data }) => {
+const Chart = ({ data, onSaveSvg }) => {
     const svgRef = useRef();
 
     useEffect(() => {
@@ -151,8 +151,12 @@ const Chart = ({ data }) => {
                 movedPointer(event);
             })
             .on("touchstart", event => event.preventDefault());
+
+        if (onSaveSvg && svgRef.current) {
+            onSaveSvg(svgRef.current);
+        }   
             
-        }, [data]);
+        }, [data, onSaveSvg]);
 
 
         return (


### PR DESCRIPTION
## Description

- This PR adds `localStorage` caching to both selectedOptions from the react-select component as well as caching the generated svg image as a url
- I believe the PR completes TC2 !

## Milestones
<the milestones or stories/features that this works towards>
- In order for this visualization to be performant and responsive, we will have to implement a caching system

## Resources
<links to tutorials, code snippets, inspirations>
<if you took or translated specific code from the internet, please call it out here!>

- I used [this](https://developer.mozilla.org/en-US/docs/Web/API/XMLSerializer) to help with svg cacheing as url
- I used [this](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) to help give me a general understanding of localStorage caching

## Test Plan
This video shows off the caching feature by highlighting how selected options and graph persist through page refreshes and quickly logging in and out


https://github.com/user-attachments/assets/df0510c3-443a-41a9-bc4f-4c4f2019c6bf


