### PR TITLE
added skeleton goal page and routing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import SignUp from './HomePage/SignHandlers/SignUp'
 import SignIn from './HomePage/SignHandlers/SignIn';
 import CreateAccount from './ProfilePage/CreateAccount'
 import SearchResults from './SearchPage/SearchResults';
+import Goals from './GoalPage/Goals';
 import './App.css'
 
 function App() {
@@ -21,6 +22,7 @@ function App() {
         <Route path="/createprofile/:userId" element={<CreateAccount/>}/>
         <Route path="/search/:searchTerm" element={<SearchResults/>}/>
         <Route path="/profile/:userId/search/:searchTerm" element={<SearchResults/>}/>
+        <Route path = "/goals/:userId" element={<Goals/>}/>
       </Routes>
     </BrowserRouter>
   )

--- a/frontend/src/GoalPage/Goals.css
+++ b/frontend/src/GoalPage/Goals.css
@@ -1,0 +1,21 @@
+.TopBar {
+    display: block;
+    position: fixed;
+}
+
+.ActiveGoals {
+    margin-top: 25vh;
+    margin-left: 100vw;
+}
+
+h2 {
+    font-family: "Inter Tight", sans-serif;
+    font-weight: 400;
+    margin-bottom: 8%;
+    font-size: 20pt;
+    margin-left: 5%;
+}
+
+.GoalPageContent {
+    margin-left: 20vw;
+}

--- a/frontend/src/GoalPage/Goals.jsx
+++ b/frontend/src/GoalPage/Goals.jsx
@@ -10,7 +10,7 @@ function Goals() {
         <div className='GoalPageContent'>
             <div className='ActiveGoals'></div>
                 <div className='ActiveGoalsContent'>
-                        <h2> Your Goals</h2>
+                        <h2> Your Active Goals</h2>
                         <div className='GoalsList'>
                         </div>
                 </div>

--- a/frontend/src/GoalPage/Goals.jsx
+++ b/frontend/src/GoalPage/Goals.jsx
@@ -1,0 +1,39 @@
+import './Goals.css'
+import ProfileTopBar from '../ProfilePage/ProfileTopBar';
+
+function Goals() {
+    return (
+        <>
+        <div className='TopBar'>
+            <ProfileTopBar/>
+        </div>
+        <div className='GoalPageContent'>
+            <div className='ActiveGoals'></div>
+                <div className='ActiveGoalsContent'>
+                        <h2> Your Goals</h2>
+                        <div className='GoalsList'>
+                        </div>
+                </div>
+            <div className='SuggestedGoals'>
+                <div className='SuggestedGoalsContent'>
+                    <h2> Personalized Suggested Goals</h2>
+                </div>
+                <div className='SuggestedList'>
+                </div>
+            </div>
+            <div className='AddGoals'>
+                <div className='AddGoalsContent'>
+                    <h2>Add a New Goal</h2>
+                    <div className='AddList'>
+
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        
+        </>
+    )
+}
+
+export default Goals;

--- a/frontend/src/ProfilePage/ProfileTopBar.css
+++ b/frontend/src/ProfilePage/ProfileTopBar.css
@@ -15,9 +15,18 @@ button {
     cursor: pointer;
 }
 
+.GoalBtn { 
+    margin-left: 15%;
+    margin-right: 0.5%;
+    background-color: #6aaa2b;
+    color: #f7f9fb;
+}
+
+.GoalBtn:hover {
+    background-color: #8CCB5E;
+}
 
 .ProfileBtn {
-    margin-left: 20%;
     margin-right: .5%;
     background-color: #cfd6dc;
     color: #36454f

--- a/frontend/src/ProfilePage/ProfileTopBar.jsx
+++ b/frontend/src/ProfilePage/ProfileTopBar.jsx
@@ -17,6 +17,7 @@ function ProfileTopBar () {
             </div>
             <p className='TopName' onClick={() => navigate(`/search/${menloPark}`)}>EconMetrics</p>
             <Search/>
+            <button className='GoalBtn' onClick={() => navigate(`/goals/${userId}`)}>Goals</button>
             <button className='ProfileBtn' onClick={() => navigate(`/profile/${userId}`)}>Your Profile</button>
             <button className='LogOutBtn' onClick={() => navigate(`/search/${menloPark}` , {replace: true})}>Log Out</button>
         </div>


### PR DESCRIPTION
## Description

- For this PR I added a new button at the top of the `ProfileTopBar` component to allow users to navigate onto the "goals page" 
- I also populated the goals page with the basic wireframe content structure

- My next few PRs are going to improve on other features, adding a second graph for TC2 and I want to finally get to the edit profile button 
- Specifically for this area of work (TC1), the next step would be to create a new database table for goals and get goals data on to the client side, as well as integrating email api (nylas or nodemailer still undecided) 

## Milestones
This PR works toward: 
- Users that have logged in can navigate to a goals page to track goals, view personalized goals recommendations, and see a list of all available goals
- After goals are set, EconMetrics provides users with personalized plans to meet their goals based on user preferences, other users who have accomplished similar goals, and market conditions.

## Test Plan
This shows a screenshot of the goal page wireframe, this is what you see when you click on the "goals" button on profile top bar
<img width="1640" alt="Screenshot 2024-07-19 at 3 32 13 PM" src="https://github.com/user-attachments/assets/305c999d-9bfa-440d-9c12-c9481d023d38">

